### PR TITLE
Fix paths that `withCheck` reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Forma 1.1.1
+
+* Fixed a bug which caused `withCheck` (and functions using it such as
+  `field`) report incorrect location of element for which validation fails
+  when it's nested in `subParser` wrappers.
+
 ## Forma 1.1.0
 
 * Added `runFormPure`.

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -174,6 +174,34 @@ spec = do
           msg = "This field cannot be empty."
       r <- runForm p input
       r `shouldBe` ValidationFailed (M.singleton #username msg)
+  describe "withCheck" $ do
+    let p :: Monad m => FormParser LoginFields Text m Text
+        p = subParser #username
+          $ subParser #password
+          $ field #remember_me notEmpty
+    it "reports correct path and error when parsing fails" $ do
+      let input = object
+            [ "username" .= object
+              [ "password" .= object
+                [ "remember_me" .= Bool False
+                ]
+              ]
+            ]
+      r <- runForm p input
+      r `shouldBe` ParsingFailed (pure (#username <> #password <> #remember_me))
+                                 "expected Text, encountered Boolean"
+    it "reports correct path and error when validation fails" $ do
+      let input = object
+            [ "username" .= object
+              [ "password" .= object
+                [ "remember_me" .= String ""
+                ]
+              ]
+            ]
+          msg = "This field cannot be empty."
+      r <- runForm p input
+      r `shouldBe` ValidationFailed
+        (M.singleton (#username <> #password <> #remember_me) msg)
   describe "Forma (older test suite)" $ do
     context "when a parse error happens" $
       it "it's reported immediately" $ do


### PR DESCRIPTION
Fixes a bug which caused `withCheck` (and functions using it such as `field`) report incorrect location of element for which validation fails when it's nested in `subParser` wrappers.

Close #24.